### PR TITLE
Add go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module main
+
+go 1.17


### PR DESCRIPTION
添加go.mod，让go 1.17以上版本能正常编译。